### PR TITLE
add posibility to output only main dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,19 @@ Usage: peodd [OPTIONS]
   Script to export the pyproject.toml dev-dependencies to a txt file.
 
 Options:
-  -o, --output TEXT  Output file for the dependencies  [default: requirements-
-                     dev.txt]
-
+  -o, --output TEXT  Output filename for the dependencies
+  --non-dev          Output non-dev dependencies  [default: False]
   --help             Show this message and exit.
 ```
 
 Export the dev-dependencies to `requirements-dev.txt` file
 ```
 $ peodd -o requirements-dev.txt
+```
+
+Export the non-dev dependencies to `requirements.txt` file
+```
+$ peodd --non-dev -o requirements.txt
 ```
 
 ## Contributions

--- a/peodd/peodd.py
+++ b/peodd/peodd.py
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Venu Vardhan Reddy Tekula <venu@chaoss.community>
+#     Lewi Uberg <lewi@uberg.me>
 #
 
 
@@ -28,20 +29,22 @@ import re
 
 import click
 import tomli
-
 from release_tools.project import Project
-from release_tools.semverup import find_pyproject_file
 from release_tools.repo import RepositoryError
+from release_tools.semverup import find_pyproject_file
 
 VERSION_NUMBER_REGEX = r"\d+(?:\.\d+)+"
 
 
 @click.command()
 @click.option('-o', '--output',
-              default="requirements-dev.txt",
+              help="Output filename for the dependencies")
+@click.option('--non-dev',
+              default=False,
               show_default=True,
-              help="Output file for the dependencies")
-def main(output):
+              is_flag=True,
+              help="Output non-dev dependencies")
+def main(output, non_dev):
     """Script to export the pyproject.toml dev-dependencies to a txt file."""
     try:
         project = Project(os.getcwd())
@@ -58,12 +61,17 @@ def main(output):
             msg = "{} file is not valid".format(pyproject_file)
             raise click.ClickException(msg)
 
-    poetry_dev_dependencies = toml_dict["tool"]["poetry"]["dev-dependencies"]
+    if non_dev:
+        dependencies = toml_dict["tool"]["poetry"]["dependencies"]
+        click.echo("Collected dependencies ...", nl=False)
+    else:
+        dependencies = toml_dict["tool"]["poetry"]["dev-dependencies"]
+        click.echo("Collected dev-dependencies ...", nl=False)
 
-    click.echo("Collected the dev-dependencies")
+    click.echo("done")
 
     with open(output, "w") as fp:
-        for k, v in poetry_dev_dependencies.items():
+        for k, v in dependencies.items():
             try:
                 version = re.findall(VERSION_NUMBER_REGEX, v)[0]
             except TypeError:

--- a/releases/unreleased/add-support-for-exporting-non-dev-dependencies.yml
+++ b/releases/unreleased/add-support-for-exporting-non-dev-dependencies.yml
@@ -1,0 +1,10 @@
+---
+title: Add support for exporting non-dev dependencies
+category: added
+author: Lewi Uberg <lewi@uberg.me>
+issue: null
+notes: >
+  Add possibility to export only non-dev dependencies to a txt file
+  with the `--non-dev` flag, and remove the default filename, forcing
+  the user to provide one with the `-o`, `--output` flag.
+  Usage: ``` $ peodd --non-dev -o requirements.txt ```


### PR DESCRIPTION
peodd has a much cleaner output than poetry

### Description
add posibility to output only main dependencies
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
