### PR TITLE
Refactor code to support other formats

### DIFF
--- a/peodd/peodd.py
+++ b/peodd/peodd.py
@@ -36,6 +36,22 @@ from release_tools.semverup import find_pyproject_file
 VERSION_NUMBER_REGEX = r"\d+(?:\.\d+)+"
 
 
+def write_package_version_to_file(fp, k, v):
+    version = re.findall(VERSION_NUMBER_REGEX, v)[0]
+
+    if '^' in v or '>=' in v:
+        fp.write("{}>={}\n".format(k, version))
+        click.echo("{}>={} ...".format(k, version), nl=False)
+    elif v == version:
+        fp.write("{}=={}\n".format(k, version))
+        click.echo("{}=={} ...".format(k, version), nl=False)
+    else:
+        msg = "Wrong version number"
+        raise click.ClickException(msg)
+
+    click.echo("done")
+
+
 @click.command()
 @click.option('-o', '--output',
               required=True,
@@ -74,21 +90,12 @@ def main(output, non_dev):
     with open(output, "w") as fp:
         for k, v in dependencies.items():
             try:
-                version = re.findall(VERSION_NUMBER_REGEX, v)[0]
+                write_package_version_to_file(fp, k, v)
             except TypeError:
-                msg = "Not a version number, skipping"
-                click.echo(msg)
-                continue
-            if '^' in v or '>=' in v:
-                fp.write("{}>={}\n".format(k, version))
-                click.echo("{}>={} ...".format(k, version), nl=False)
-            elif v == version:
-                fp.write("{}=={}\n".format(k, version))
-                click.echo("{}=={} ...".format(k, version), nl=False)
-            else:
-                msg = "Please check the version number"
+                msg = "Format not supported"
+                # You can open an issue at https://github.com/vchrombie/peodd
+                # for reporting this and more discussion
                 raise click.ClickException(msg)
-            click.echo("done")
 
     click.echo("Export complete")
 

--- a/releases/unreleased/change-the-way-how-peodd-handles-unsupported-dependency-format.yml
+++ b/releases/unreleased/change-the-way-how-peodd-handles-unsupported-dependency-format.yml
@@ -1,0 +1,9 @@
+---
+title: Change the way how peodd handles unsupported dependency format
+category: changed
+author: Venu Vardhan Reddy Tekula <venu@chaoss.community>
+issue: null
+notes: >
+    Earlier, peodd used to skip any dependency if it is not supported.
+    This is changed and now it raises an exception saying the format
+    is not supported and stops the program.

--- a/tests/test_peodd.py
+++ b/tests/test_peodd.py
@@ -78,11 +78,11 @@ INVALID_PYPROJECT_TOML_ERROR = (
 )
 
 INVALID_VERSION_NUMBER_ERROR = (
-    "Error: Please check the version number"
+    "Error: Wrong version number"
 )
 
-GIT_URL_DEPENDENCY_SKIPPED_REQUIREMENTS_TXT = (
-    "foo>=1.2.1\nbaz==1.2.3\n"
+INVALID_DEPENDENCY_FORMAT_ERROR = (
+    "Error: Format not supported"
 )
 
 
@@ -223,13 +223,12 @@ class TestPeodd(unittest.TestCase):
 
             # Run the script command
             result = runner.invoke(peodd.main, ['-o', 'requirements-dev.txt'])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 1)
 
-            filepath = os.path.join(fs, 'requirements-dev.txt')
-            with open(filepath, 'r') as fd:
-                text = fd.read()
+            self.assertRaises(Exception)
 
-            self.assertEqual(text, GIT_URL_DEPENDENCY_SKIPPED_REQUIREMENTS_TXT)
+            lines = result.stderr.split('\n')
+            self.assertEqual(lines[-2], INVALID_DEPENDENCY_FORMAT_ERROR.format(fs))
 
     def test_version(self):
         self.assertRegex(__version__, peodd.VERSION_NUMBER_REGEX)


### PR DESCRIPTION
### Description
This commit refactors the code to support peodd exporting other types of dependencies. It also changes the way the tool handles the dependency format which is not supported. If the tool encounters any non-supported format, it raises an exception.
The tests are updated accordingly.
 
### Issues Resolved
Aiming to solve #3 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 