### PR TITLE
[peodd] Add support for poetry extras

### DIFF
--- a/peodd/peodd.py
+++ b/peodd/peodd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CHAOSS
+# Copyright (C) 2022 CHAOSS
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -89,13 +89,16 @@ def main(output, non_dev):
 
     with open(output, "w") as fp:
         for k, v in dependencies.items():
-            try:
-                write_package_version_to_file(fp, k, v)
-            except TypeError:
-                msg = "Format not supported"
-                # You can open an issue at https://github.com/vchrombie/peodd
-                # for reporting this and more discussion
-                raise click.ClickException(msg)
+            if type(v) is dict:
+                try:
+                    v = v['version']
+                except KeyError:
+                    msg = "Format not supported"
+                    # You can open an issue at https://github.com/vchrombie/peodd
+                    # for reporting this and more discussion
+                    raise click.ClickException(msg)
+
+            write_package_version_to_file(fp, k, v)
 
     click.echo("Export complete")
 

--- a/releases/unreleased/add-support-for-poetry-extras.yml
+++ b/releases/unreleased/add-support-for-poetry-extras.yml
@@ -1,0 +1,10 @@
+---
+title: Add support for poetry extras
+category: added
+author: Venu Vardhan Reddy Tekula <venu@chaoss.community>
+issue: 3
+notes: >
+    This feature adds support for exporting poetry extras.
+    The extras dependency will have a dictionary with the
+    version number. The name and version is extracted and
+    is written to the file.

--- a/tests/test_peodd.py
+++ b/tests/test_peodd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CHAOSS
+# Copyright (C) 2022 CHAOSS
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,11 +35,13 @@ DEPENDENCIES_CONTENT_PYPROJECT_TOML = """
 [tool.poetry.dependencies]
 foo1 = "^1.2.3"
 bar1 = ">=1.2.3"
+bas1 = {extras = ["bar1"], version = "^1.2.3"}
 baz1 = "1.2.3"
 
 [tool.poetry.dev-dependencies]
 foo2 = "^1.2.3"
 bar2 = ">=1.2.3"
+bas2 = {extras = ["bar2"], version = "^1.2.3"}
 baz2 = "1.2.3"
 """
 
@@ -65,11 +67,11 @@ baz = "1.2.3"
 """
 
 NON_DEV_DEPENDENCIES_CONTENT_REQUIREMENTS_TXT = (
-    "foo1>=1.2.3\nbar1>=1.2.3\nbaz1==1.2.3\n"
+    "foo1>=1.2.3\nbar1>=1.2.3\nbas1>=1.2.3\nbaz1==1.2.3\n"
 )
 
 DEV_DEPENDENCIES_CONTENT_REQUIREMENTS_TXT = (
-    "foo2>=1.2.3\nbar2>=1.2.3\nbaz2==1.2.3\n"
+    "foo2>=1.2.3\nbar2>=1.2.3\nbas2>=1.2.3\nbaz2==1.2.3\n"
 )
 
 MOCK_REPOSITORY_ERROR = (


### PR DESCRIPTION
### Description
This PR adds support for poetry extras. The extras dependency will have a dictionary with a version number as a key. The version number is extracted and is written to the file. The tests are added accordingly.
 
### Issues Resolved
Fixes #3 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 